### PR TITLE
Adds a Dogstatsd Tag Filter (additional commits on upstream PR #6526)

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -339,6 +339,7 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("dogstatsd_so_rcvbuf", 0)
 	config.BindEnvAndSetDefault("dogstatsd_metrics_stats_enable", false)
 	config.BindEnvAndSetDefault("dogstatsd_tags", []string{})
+	config.BindEnvAndSetDefault("dogstatsd_tag_filters", []string{})
 	config.BindEnvAndSetDefault("dogstatsd_mapper_cache_size", 1000)
 	config.BindEnvAndSetDefault("dogstatsd_string_interner_size", 4096)
 	// Enable check for Entity-ID presence when enriching Dogstatsd metrics with tags

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -1071,6 +1071,20 @@ api_key:
 # dogstatsd_tags:
 #   - <TAG_KEY>:<TAG_VALUE>
 
+## @param dogstatsd_tag_filters - list of regular expressions - optional
+## List of regular expressions used to filter out (remove) tags from incoming dogstatsd samples.
+#
+# dogstatsd_tag_filters:
+## Remove any tag that matches "tag_name:tag_value":
+#   - tag_name:tag_value
+## Remove any tag with an empty value:
+#   - :$
+## Remove any tag containing a UUID:
+#   - [a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}
+## Strip an unwanted string suffix from a tag:
+#   - ^(?P<Keep>calling_service:[^/]+)  # calling_service:foo/1.2.3 => calling_service:foo
+
+
 ## @param dogstatsd_mapper_profiles - list of custom object - optional
 ## The profiles will be used to convert parts of metrics names into tags.
 ## If a profile prefix is matched, other profiles won't be tried even if that profile matching rules doesn't match.

--- a/pkg/dogstatsd/filter/filter.go
+++ b/pkg/dogstatsd/filter/filter.go
@@ -58,7 +58,7 @@ OUTER:
 	for _, regex := range tf.filters {
 		if m := regex.FindStringSubmatch(tag); m != nil {
 			for i, name := range regex.SubexpNames() {
-				if strings.ToLower(name) == "check" {
+				if strings.ToLower(name) == "keep" {
 					if strings.Contains(m[i], tagSeparator) {
 						// overwrite tag as the match group
 						tag = m[i]

--- a/pkg/dogstatsd/filter/filter.go
+++ b/pkg/dogstatsd/filter/filter.go
@@ -1,0 +1,62 @@
+package filter
+
+import (
+	"regexp"
+	"strings"
+)
+
+type TagFilter struct {
+	filters []*regexp.Regexp
+}
+
+func NewTagFilter(regexes []string) (*TagFilter, error) {
+	filters := make([]*regexp.Regexp, len(regexes))
+	for i, r := range regexes {
+		if regex, err := regexp.Compile(r); err != nil {
+			return nil, err
+		} else {
+			filters[i] = regex
+		}
+	}
+
+	return &TagFilter{
+		filters: filters,
+	}, nil
+}
+
+func (tf *TagFilter) Filter(tags []string) []string {
+	var i int
+	for _, t := range tags {
+		if ok, result := tf.filter(t); ok {
+			tags[i] = result
+			i++
+		}
+	}
+
+	// Prevent memory leak by erasing truncated values
+	for j := i; j < len(tags); j++ {
+		tags[j] = ""
+	}
+
+	return tags[:i]
+}
+
+func (tf *TagFilter) filter(tag string) (bool, string) {
+	OUTER:
+	for _, regex := range tf.filters {
+		if m := regex.FindStringSubmatch(tag); m != nil {
+			for i, name := range regex.SubexpNames() {
+				if name == "Keep" {
+					if strings.Contains(m[i], ":") {
+						tag = m[i]
+					}
+					continue OUTER
+				}
+			}
+
+			return false, ""
+		}
+	}
+
+	return true, tag
+}

--- a/pkg/dogstatsd/filter/filter.go
+++ b/pkg/dogstatsd/filter/filter.go
@@ -5,11 +5,16 @@ import (
 	"strings"
 )
 
+const tagSeparator = ":"
+
+// TagFilter filters a slice of tags against a list of regular expressions
 type TagFilter struct {
 	filters []*regexp.Regexp
 }
 
-func NewTagFilter(regexes []string) (*TagFilter, error) {
+// New compiles a list of regular expressions and returns a TagFilter or an
+// error if one of the expressions fails not compile
+func New(regexes []string) (*TagFilter, error) {
 	filters := make([]*regexp.Regexp, len(regexes))
 	for i, r := range regexes {
 		regex, err := regexp.Compile(r)
@@ -24,16 +29,21 @@ func NewTagFilter(regexes []string) (*TagFilter, error) {
 	}, nil
 }
 
+// Filter a slice of tags against a pre-compiled list of regular expressions
+// and return a list of tags. Undesirable tags that match an expression are
+// removed. Any expression that contains a match group named "Keep" will return
+// only the matching substring if and only if that substring contains the
+// required ':' tag separator.
 func (tf *TagFilter) Filter(tags []string) []string {
 	var i int
 	for _, t := range tags {
-		if ok, result := tf.filter(t); ok {
+		if keep, result := tf.check(t); keep {
 			tags[i] = result
 			i++
 		}
 	}
 
-	// Prevent memory leak by erasing truncated values
+	// Optimization: erase truncated values in the backing array
 	for j := i; j < len(tags); j++ {
 		tags[j] = ""
 	}
@@ -41,13 +51,16 @@ func (tf *TagFilter) Filter(tags []string) []string {
 	return tags[:i]
 }
 
-func (tf *TagFilter) filter(tag string) (bool, string) {
+// check returns true if the tag should be kept or replaced with the second
+// string and false when the tag should be filtered.
+func (tf *TagFilter) check(tag string) (bool, string) {
 OUTER:
 	for _, regex := range tf.filters {
 		if m := regex.FindStringSubmatch(tag); m != nil {
 			for i, name := range regex.SubexpNames() {
-				if name == "Keep" {
-					if strings.Contains(m[i], ":") {
+				if strings.ToLower(name) == "check" {
+					if strings.Contains(m[i], tagSeparator) {
+						// overwrite tag as the match group
 						tag = m[i]
 					}
 					continue OUTER

--- a/pkg/dogstatsd/filter/filter.go
+++ b/pkg/dogstatsd/filter/filter.go
@@ -12,13 +12,13 @@ type TagFilter struct {
 func NewTagFilter(regexes []string) (*TagFilter, error) {
 	filters := make([]*regexp.Regexp, len(regexes))
 	for i, r := range regexes {
-		if regex, err := regexp.Compile(r); err != nil {
+		regex, err := regexp.Compile(r)
+		if err != nil {
 			return nil, err
-		} else {
-			filters[i] = regex
 		}
-	}
 
+		filters[i] = regex
+	}
 	return &TagFilter{
 		filters: filters,
 	}, nil
@@ -42,7 +42,7 @@ func (tf *TagFilter) Filter(tags []string) []string {
 }
 
 func (tf *TagFilter) filter(tag string) (bool, string) {
-	OUTER:
+OUTER:
 	for _, regex := range tf.filters {
 		if m := regex.FindStringSubmatch(tag); m != nil {
 			for i, name := range regex.SubexpNames() {

--- a/pkg/dogstatsd/filter/filter_test.go
+++ b/pkg/dogstatsd/filter/filter_test.go
@@ -42,9 +42,9 @@ func TestTagFilter_Filter(t *testing.T) {
 			want: []string{"calling_service:foo"},
 		},
 		{
-			name: "keep match group that removes colon separator",
-			args: args{[]string{"keep:without colon"}},
-			want: []string{"keep:without colon"},
+			name: "check match group that removes colon separator",
+			args: args{[]string{"check:without colon"}},
+			want: []string{"check:without colon"},
 		},
 		{
 			name: "drop untitled match group",
@@ -77,7 +77,7 @@ func TestTagFilter_Filter(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			tf, err := NewTagFilter([]string{
+			tf, err := New([]string{
 				// A match group named "Keep" will remove anything not matched by the match group
 				"^(?P<Keep>calling_service:[^/]+)",
 				"(?P<Keep>without colon)",

--- a/pkg/dogstatsd/filter/filter_test.go
+++ b/pkg/dogstatsd/filter/filter_test.go
@@ -1,0 +1,97 @@
+package filter
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTagFilter_Filter(t *testing.T) {
+	type args struct {
+		tags []string
+	}
+	tests := []struct {
+		name string
+		args args
+		want []string
+	}{
+		{
+			name: "nil",
+			args: args{},
+			want: nil,
+		},
+		{
+			name: "empty",
+			args: args{[]string{}},
+			want: []string{},
+		},
+		{
+			name: "unchanged",
+			args: args{[]string{"key:value"}},
+			want: []string{"key:value"},
+		},
+		{
+			name: "filtered",
+			args: args{[]string{"key:drop_me"}},
+			want: []string{},
+		},
+		{
+			name: "mangled",
+			args: args{[]string{"calling_service:foo/e84f81f89e3876b2b11db348e95c8ab056e134ac"}},
+			want: []string{"calling_service:foo"},
+		},
+		{
+			name: "keep match group that removes colon separator",
+			args: args{[]string{"keep:without colon"}},
+			want: []string{"keep:without colon"},
+		},
+		{
+			name: "drop untitled match group",
+			args: args{[]string{"drop:untitled match group"}},
+			want: []string{},
+		},
+		{
+			name: "drop after mangled",
+			args: args{[]string{"drop:after mangled"}},
+			want: []string{},
+		},
+		{
+			name: "multi tag filter",
+			args: args{[]string{
+				"calling_service:foo/e84f81f89e3876b2b11db348e95c8ab056e134ac",
+				"key:drop_me",
+				"key:value",
+				"version:",
+				"version:1.0.0",
+				"request_id:CA761232-ED42-11CE-BACD-00AA0057B223",
+				"request_source:CA761232-ED42-11CE-BACD-00AA0057B223",
+				"request_source:genCA761232-ED42-11CE-BACD-00AA0057B223",
+			}},
+			want: []string{
+				"calling_service:foo",
+				"key:value",
+				"version:1.0.0",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tf, err := NewTagFilter([]string{
+				// A match group named "Keep" will remove anything not matched by the match group
+				"^(?P<Keep>calling_service:[^/]+)",
+				"(?P<Keep>without colon)",
+				"(?P<Keep>drop:after)",
+				":$", // remove empty string tag values
+				"^drop:after$",
+				"(untitled match group)",
+				`[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}`, // uuid
+				"drop_me",
+			})
+			assert.NoError(t, err)
+			if got := tf.Filter(tt.args.tags); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("Filter() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/dogstatsd/server.go
+++ b/pkg/dogstatsd/server.go
@@ -191,7 +191,7 @@ func NewServer(aggregator *aggregator.BufferedAggregator) (*Server, error) {
 	tagFilters := config.Datadog.GetStringSlice("dogstatsd_tag_filters")
 	if len(tagFilters) > 0 {
 		var err error
-		if tagFilter, err = filter.NewTagFilter(tagFilters); err != nil {
+		if tagFilter, err = filter.New(tagFilters); err != nil {
 			log.Errorf("Dogstatsd: unable to create tag filters: %s", err.Error())
 		}
 	}

--- a/pkg/dogstatsd/server.go
+++ b/pkg/dogstatsd/server.go
@@ -447,9 +447,6 @@ func (s *Server) parseMetricMessage(parser *parser, message []byte, originTagsFu
 		tlmProcessed.IncWithTags(tlmProcessedErrorTags)
 		return metrics.MetricSample{}, err
 	}
-	if s.filter != nil {
-		sample.tags = s.filter.Filter(sample.tags)
-	}
 	if s.mapper != nil {
 		mapResult := s.mapper.Map(sample.name)
 		if mapResult != nil {
@@ -460,6 +457,11 @@ func (s *Server) parseMetricMessage(parser *parser, message []byte, originTagsFu
 	}
 	metricSample := enrichMetricSample(sample, s.metricPrefix, s.metricPrefixBlacklist, s.defaultHostname, originTagsFunc, s.entityIDPrecedenceEnabled)
 	metricSample.Tags = append(metricSample.Tags, s.extraTags...)
+
+	if s.filter != nil {
+		metricSample.Tags = s.filter.Filter(metricSample.Tags)
+	}
+
 	dogstatsdMetricPackets.Add(1)
 	tlmProcessed.IncWithTags(tlmProcessedOkTags)
 	return metricSample, nil

--- a/releasenotes/notes/Adds-a-filtering-capability-to-the-dogstatsd-server-that-removes-or-modifies-undesirable-tags-122a4e2fc347e95e.yaml
+++ b/releasenotes/notes/Adds-a-filtering-capability-to-the-dogstatsd-server-that-removes-or-modifies-undesirable-tags-122a4e2fc347e95e.yaml
@@ -1,0 +1,39 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+upgrade:
+  - |
+    List upgrade notes here, or remove this section.
+    Upgrade notes should be rare: only list known/potential breaking changes,
+    or major behaviorial changes that require user action before the upgrade.
+    Notes here must include steps that users can follow to 1. know if they're
+    affected and 2. handle the change gracefully on their end.
+features:
+  - |
+    List new features here, or remove this section.
+enhancements:
+  - |
+    List enhancements (new behavior that is too small to be
+    considered a new feature), or remove this section.
+issues:
+  - |
+    List known issues here, or remove this section.
+deprecations:
+  - |
+    List deprecations notes here, or remove this section.
+security:
+  - |
+    Add security notes here, or remove this section.
+fixes:
+  - |
+    Add normal bug fixes here, or remove this section.
+other:
+  - |
+    Add here every other information you want in the CHANGELOG that
+    don't fit in any other section. This section should rarely be
+    used.


### PR DESCRIPTION
### What does this PR do?

This PR adds a tag filter to restrict which tags are sent to the datadog API.
In addition to the changes in upstream PR #6526, this PR moves the filter to after tag enrichment
so that it can also filter out tags detected from the host. (e.g. AWS and ECS automatic tags).

### Motivation

ARNs such as the AWS Fleet ID, launch template IDs and the ECS container instance id are high entropy
tags that aren't that much more useful than the EC2 instance id (which is already sent as the host tag).

There already exists the `exclude_gce_tags` config option, but that's limited to google cloud tags only.

